### PR TITLE
Folder更新機能実装

### DIFF
--- a/src/application/folder/create_folder_usecase.go
+++ b/src/application/folder/create_folder_usecase.go
@@ -38,7 +38,7 @@ func (uc *CreateFolderUseCase) Run(
 		return nil, err
 	}
 
-	t, err := folderDomain.NewFolder(dto.Title, sub)
+	t, err := folderDomain.NewFolder(sub, dto.Title)
 	if err != nil {
 		logging.Logger.Error("Failed to create new folder", "error", err)
 		return nil, err

--- a/src/application/folder/update_folder_usecase.go
+++ b/src/application/folder/update_folder_usecase.go
@@ -1,0 +1,57 @@
+package folder
+
+import (
+	"context"
+
+	folderDomain "github.com/shinya-ac/server1Q1A/domain/folder"
+	"github.com/shinya-ac/server1Q1A/pkg/auth"
+	"github.com/shinya-ac/server1Q1A/pkg/logging"
+)
+
+type UpdateFolderUseCase struct {
+	folderRepo folderDomain.FolderRepository
+}
+
+func NewUpdateFolderUseCase(
+	folderRepo folderDomain.FolderRepository,
+) *UpdateFolderUseCase {
+	return &UpdateFolderUseCase{
+		folderRepo: folderRepo,
+	}
+}
+
+type UpdateFolderUseCaseInputDto struct {
+	Id    string
+	Title string
+}
+
+func (uc *UpdateFolderUseCase) Run(
+	ctx context.Context,
+	dto UpdateFolderUseCaseInputDto,
+) error {
+	sub, err := auth.GetUserIDFromContext(ctx)
+	if err != nil {
+		logging.Logger.Error("UserIdの取得に失敗しました", err)
+		return err
+	}
+
+	folder, err := uc.folderRepo.FindById(ctx, dto.Id)
+	if err != nil {
+		logging.Logger.Error("Folderが存在しません", "error", err)
+		return err
+	}
+
+	updatedFolder, err := folderDomain.ReconstructFolder(folder.Id, dto.Title, sub)
+	if err != nil {
+		logging.Logger.Error("Folderの作成に失敗しました", "error", err)
+		return err
+	}
+
+	err = uc.folderRepo.Update(ctx, updatedFolder)
+	if err != nil {
+		logging.Logger.Error("Folderの更新に失敗しました", "error", err)
+		return err
+	}
+
+	return nil
+}

--- a/src/domain/folder/folder.go
+++ b/src/domain/folder/folder.go
@@ -15,26 +15,27 @@ type Folder struct {
 	UserId string
 }
 
-func NewFolder(
-	Title string,
-	UserId string,
-) (*Folder, error) {
-	if utf8.RuneCountInString(Title) < titleLengthMin || utf8.RuneCountInString(Title) > titleLengthMax {
+func newFolder(id, title, userId string) (*Folder, error) {
+	if utf8.RuneCountInString(title) < titleLengthMin || utf8.RuneCountInString(title) > titleLengthMax {
 		err := errDomain.NewError("タイトルの値が不正です。")
 		logging.Logger.Error("タイトルの値が不正", "error", err)
 		return nil, err
 	}
-	id, err := uuid.NewRandom()
-	if err != nil {
-		logging.Logger.Error("UUIDの生成に失敗", "error", err)
-		return nil, err
-	}
 
 	return &Folder{
-		Id:     id.String(),
-		Title:  Title,
-		UserId: UserId,
+		Id:     id,
+		Title:  title,
+		UserId: userId,
 	}, nil
+}
+
+func NewFolder(userId, title string) (*Folder, error) {
+	id := uuid.New().String()
+	return newFolder(id, title, userId)
+}
+
+func ReconstructFolder(id, title, userId string) (*Folder, error) {
+	return newFolder(id, title, userId)
 }
 
 func (f *Folder) GetId() string {

--- a/src/domain/folder/folder_repository.go
+++ b/src/domain/folder/folder_repository.go
@@ -8,4 +8,5 @@ type FolderRepository interface {
 	Create(ctx context.Context, folder *Folder) error
 	FindById(ctx context.Context, id string) (*Folder, error)
 	Delete(ctx context.Context, folderId string) error
+	Update(ctx context.Context, folder *Folder) error
 }

--- a/src/infrastructure/mysql/repository/folder_repository.go
+++ b/src/infrastructure/mysql/repository/folder_repository.go
@@ -60,3 +60,18 @@ func (r *FolderRepository) Delete(ctx context.Context, folderId string) error {
 	}
 	return nil
 }
+
+func (r *FolderRepository) Update(ctx context.Context, folder *folder.Folder) error {
+	if folder == nil {
+		logging.Logger.Error("Folderがnil")
+		err := errDomain.NewError("Folderがnilです。")
+		return err
+	}
+	query := `UPDATE folders SET title = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`
+	_, err := r.db.ExecContext(ctx, query, folder.Title, folder.Id)
+	if err != nil {
+		logging.Logger.Error("Folderの更新に失敗しました", "error", err)
+		return err
+	}
+	return nil
+}

--- a/src/presentation/folder/request.go
+++ b/src/presentation/folder/request.go
@@ -3,3 +3,7 @@ package folder
 type CreateFolderParams struct {
 	Title string `json:"title" validate:"required" example:"日本史"`
 }
+
+type UpdateFolderParams struct {
+	Title string `json:"title" validate:"required" example:"日本史B"`
+}

--- a/src/server/route/route.go
+++ b/src/server/route/route.go
@@ -32,9 +32,11 @@ func folderRoute(r *echo.Group) {
 	folderRepository := repository.NewFolderRepository(db.GetDB())
 	cuc := folderApp.NewCreateFolderUseCase(folderRepository)
 	duc := folderApp.NewDeleteFolderUseCase(folderRepository)
-	h := folderPre.NewHandler(cuc, duc)
+	uuc := folderApp.NewUpdateFolderUseCase(folderRepository)
+	h := folderPre.NewHandler(cuc, duc, uuc)
 
 	group := r.Group("/folders")
 	group.POST("/", h.CreateFolders)
+	group.PATCH("/:id", h.UpdateFolder)
 	group.DELETE("/:id", h.DeleteFolder)
 }


### PR DESCRIPTION
Folderエンティティの生成ロジックを更新系を考慮したものに変更

具体的にはReconstructというものを用意し、既存のNewFolderもnewFolderとNewFolderに分割し、外部から参照できるメソッドと、純粋なコンストラクタに分けた

そして更新の際にはReconstructを呼び出し、既存のFolderに対して新しいtitleの値でFolderエンティティを更新するようにする
新規作成（生成）の際にはIDはNewFolderが呼び出され、UUIDを生成した上でnewFolderに処理が移るように設計

上記のロジック変更に合わせてcreate_folderのusecaseにも多少の修正を加えた