### PR TITLE
AIへのプロンプトをmicrocmsから取得するように改修

### DIFF
--- a/src/application/chatgpt/chatgpt_client.go
+++ b/src/application/chatgpt/chatgpt_client.go
@@ -9,5 +9,5 @@ type Qas struct {
 
 type ChatGptClient interface {
 	GenerateQas(ctx context.Context, content string) ([]*Qas, error)
-	Ocr(ctx context.Context, imageURL string) (string, error)
+	Ocr(ctx context.Context, imageURL string, contentID string) (string, error)
 }

--- a/src/application/chatgpt/chatgpt_client.go
+++ b/src/application/chatgpt/chatgpt_client.go
@@ -8,6 +8,6 @@ type Qas struct {
 }
 
 type ChatGptClient interface {
-	GenerateQas(ctx context.Context, content string) ([]*Qas, error)
-	Ocr(ctx context.Context, imageURL string, contentID string) (string, error)
+	GenerateQas(ctx context.Context, content, microcmsContentID string) ([]*Qas, error)
+	Ocr(ctx context.Context, imageURL string, microcmsContentID string) (string, error)
 }

--- a/src/application/chatgpt/generate_qas_usecase.go
+++ b/src/application/chatgpt/generate_qas_usecase.go
@@ -2,6 +2,8 @@ package chatgpt
 
 import (
 	"context"
+
+	config "github.com/shinya-ac/server1Q1A/configs"
 )
 
 type GenerateQasUseCase struct {
@@ -15,5 +17,10 @@ func NewGenerateQasUseCase(client ChatGptClient) *GenerateQasUseCase {
 }
 
 func (uc *GenerateQasUseCase) Run(ctx context.Context, content string) ([]*Qas, error) {
-	return uc.chatGptClient.GenerateQas(ctx, content)
+	generateQAsContentID := config.Config.MicrocmsGenerateQAsContentID
+	response, err := uc.chatGptClient.GenerateQas(ctx, content, generateQAsContentID)
+	if err != nil {
+		return nil, err
+	}
+	return response, nil
 }

--- a/src/application/chatgpt/ocr_usecase.go
+++ b/src/application/chatgpt/ocr_usecase.go
@@ -3,6 +3,7 @@ package chatgpt
 import (
 	"context"
 
+	config "github.com/shinya-ac/server1Q1A/configs"
 	"github.com/shinya-ac/server1Q1A/pkg/logging"
 )
 
@@ -16,8 +17,9 @@ func NewChatGPTUseCase(client ChatGptClient) *OcrUseCase {
 	}
 }
 
-func (uc *OcrUseCase) HandleImageAnalysis(ctx context.Context, imageURL string) (string, error) {
-	response, err := uc.chatGptClient.Ocr(ctx, imageURL)
+func (uc *OcrUseCase) HandleOcr(ctx context.Context, imageURL string) (string, error) {
+	OcrContentID := config.Config.MicrocmsOcrContentID
+	response, err := uc.chatGptClient.Ocr(ctx, imageURL, OcrContentID)
 	if err != nil {
 		return "", err
 	}

--- a/src/application/microcms/microcms_client.go
+++ b/src/application/microcms/microcms_client.go
@@ -1,0 +1,5 @@
+package microcms
+
+type MicrocmsClient interface {
+	GetPrompt(contentID string) (string, error)
+}

--- a/src/configs/config.go
+++ b/src/configs/config.go
@@ -9,22 +9,24 @@ import (
 )
 
 type ConfigList struct {
-	DBUser        string
-	DBPassword    string
-	DBHost        string
-	DBPort        string
-	DBName        string
-	CACertPath    string
-	ServerAddress string
-	ServerPort    string
-	APIKey1       string
-	APIKey2       string
-	APIKey3       string
-	AuthDomain    string
-	AuthClientID  string
-	SigningMethod string
-	DBTLSMode     string
-	ChatGptApiKey string
+	DBUser               string
+	DBPassword           string
+	DBHost               string
+	DBPort               string
+	DBName               string
+	CACertPath           string
+	ServerAddress        string
+	ServerPort           string
+	APIKey1              string
+	APIKey2              string
+	APIKey3              string
+	AuthDomain           string
+	AuthClientID         string
+	SigningMethod        string
+	DBTLSMode            string
+	ChatGptApiKey        string
+	MicrocmsApiKey       string
+	MicrocmsOcrContentID string
 }
 
 var Config ConfigList
@@ -48,22 +50,24 @@ func LoadConfig() (ConfigList, error) {
 	missingConfig := []string{}
 
 	Config = ConfigList{
-		DBUser:        getEnv("DB_USER", getINIValue(cfg, "db", "user", "")),
-		DBPassword:    getEnv("DB_PASSWORD", getINIValue(cfg, "db", "password", "")),
-		DBHost:        getEnv("DB_HOST", getINIValue(cfg, "db", "host", "")),
-		DBPort:        getEnv("DB_PORT", getINIValue(cfg, "db", "port", "")),
-		DBName:        getEnv("DB_NAME", getINIValue(cfg, "db", "name", "")),
-		CACertPath:    getEnv("CA_CERT_PATH", getINIValue(cfg, "db", "ca_cert_path", "")),
-		ServerAddress: getEnv("SERVER_ADDRESS", getINIValue(cfg, "server", "address", "")),
-		ServerPort:    getEnv("SERVER_PORT", getINIValue(cfg, "server", "port", "")),
-		APIKey1:       getEnv("API_KEY1", getINIValue(cfg, "api", "key1", "")),
-		APIKey2:       getEnv("API_KEY2", getINIValue(cfg, "api", "key2", "")),
-		APIKey3:       getEnv("API_KEY3", getINIValue(cfg, "api", "key3", "")),
-		AuthDomain:    getEnv("AUTH_DOMAIN", getINIValue(cfg, "auth0", "auth_domain", "")),
-		AuthClientID:  getEnv("AUTH_CLIENT_ID", getINIValue(cfg, "auth0", "auth_client_id", "")),
-		SigningMethod: getEnv("JWT_SIGNING_METHOD", getINIValue(cfg, "auth0", "signing_method", "")),
-		DBTLSMode:     getEnv("DB_TLS_MODE", getINIValue(cfg, "db", "tls_mode", "")),
-		ChatGptApiKey: getEnv("CHAT_GPT_API_KEY", getINIValue(cfg, "chatgpt", "api_key", "")),
+		DBUser:               getEnv("DB_USER", getINIValue(cfg, "db", "user", "")),
+		DBPassword:           getEnv("DB_PASSWORD", getINIValue(cfg, "db", "password", "")),
+		DBHost:               getEnv("DB_HOST", getINIValue(cfg, "db", "host", "")),
+		DBPort:               getEnv("DB_PORT", getINIValue(cfg, "db", "port", "")),
+		DBName:               getEnv("DB_NAME", getINIValue(cfg, "db", "name", "")),
+		CACertPath:           getEnv("CA_CERT_PATH", getINIValue(cfg, "db", "ca_cert_path", "")),
+		ServerAddress:        getEnv("SERVER_ADDRESS", getINIValue(cfg, "server", "address", "")),
+		ServerPort:           getEnv("SERVER_PORT", getINIValue(cfg, "server", "port", "")),
+		APIKey1:              getEnv("API_KEY1", getINIValue(cfg, "api", "key1", "")),
+		APIKey2:              getEnv("API_KEY2", getINIValue(cfg, "api", "key2", "")),
+		APIKey3:              getEnv("API_KEY3", getINIValue(cfg, "api", "key3", "")),
+		AuthDomain:           getEnv("AUTH_DOMAIN", getINIValue(cfg, "auth0", "auth_domain", "")),
+		AuthClientID:         getEnv("AUTH_CLIENT_ID", getINIValue(cfg, "auth0", "auth_client_id", "")),
+		SigningMethod:        getEnv("JWT_SIGNING_METHOD", getINIValue(cfg, "auth0", "signing_method", "")),
+		DBTLSMode:            getEnv("DB_TLS_MODE", getINIValue(cfg, "db", "tls_mode", "")),
+		ChatGptApiKey:        getEnv("CHAT_GPT_API_KEY", getINIValue(cfg, "chatgpt", "api_key", "")),
+		MicrocmsApiKey:       getEnv("MICROCMS_API_KEY", getINIValue(cfg, "microcms", "api_key", "")),
+		MicrocmsOcrContentID: getEnv("MICROCMS_OCR_CONTENT_ID", getINIValue(cfg, "microcms", "ocr_content_id", "")),
 	}
 
 	if Config.DBUser == "" {
@@ -113,6 +117,12 @@ func LoadConfig() (ConfigList, error) {
 	}
 	if Config.ChatGptApiKey == "" {
 		missingConfig = append(missingConfig, "CHAT_GPT_API_KEY")
+	}
+	if Config.MicrocmsApiKey == "" {
+		missingConfig = append(missingConfig, "MICROCMS_API_KEY")
+	}
+	if Config.MicrocmsOcrContentID == "" {
+		missingConfig = append(missingConfig, "MICROCMS_OCR_CONTENT_ID")
 	}
 
 	if len(missingConfig) > 0 {

--- a/src/configs/config.go
+++ b/src/configs/config.go
@@ -9,24 +9,25 @@ import (
 )
 
 type ConfigList struct {
-	DBUser               string
-	DBPassword           string
-	DBHost               string
-	DBPort               string
-	DBName               string
-	CACertPath           string
-	ServerAddress        string
-	ServerPort           string
-	APIKey1              string
-	APIKey2              string
-	APIKey3              string
-	AuthDomain           string
-	AuthClientID         string
-	SigningMethod        string
-	DBTLSMode            string
-	ChatGptApiKey        string
-	MicrocmsApiKey       string
-	MicrocmsOcrContentID string
+	DBUser                       string
+	DBPassword                   string
+	DBHost                       string
+	DBPort                       string
+	DBName                       string
+	CACertPath                   string
+	ServerAddress                string
+	ServerPort                   string
+	APIKey1                      string
+	APIKey2                      string
+	APIKey3                      string
+	AuthDomain                   string
+	AuthClientID                 string
+	SigningMethod                string
+	DBTLSMode                    string
+	ChatGptApiKey                string
+	MicrocmsApiKey               string
+	MicrocmsOcrContentID         string
+	MicrocmsGenerateQAsContentID string
 }
 
 var Config ConfigList
@@ -50,24 +51,25 @@ func LoadConfig() (ConfigList, error) {
 	missingConfig := []string{}
 
 	Config = ConfigList{
-		DBUser:               getEnv("DB_USER", getINIValue(cfg, "db", "user", "")),
-		DBPassword:           getEnv("DB_PASSWORD", getINIValue(cfg, "db", "password", "")),
-		DBHost:               getEnv("DB_HOST", getINIValue(cfg, "db", "host", "")),
-		DBPort:               getEnv("DB_PORT", getINIValue(cfg, "db", "port", "")),
-		DBName:               getEnv("DB_NAME", getINIValue(cfg, "db", "name", "")),
-		CACertPath:           getEnv("CA_CERT_PATH", getINIValue(cfg, "db", "ca_cert_path", "")),
-		ServerAddress:        getEnv("SERVER_ADDRESS", getINIValue(cfg, "server", "address", "")),
-		ServerPort:           getEnv("SERVER_PORT", getINIValue(cfg, "server", "port", "")),
-		APIKey1:              getEnv("API_KEY1", getINIValue(cfg, "api", "key1", "")),
-		APIKey2:              getEnv("API_KEY2", getINIValue(cfg, "api", "key2", "")),
-		APIKey3:              getEnv("API_KEY3", getINIValue(cfg, "api", "key3", "")),
-		AuthDomain:           getEnv("AUTH_DOMAIN", getINIValue(cfg, "auth0", "auth_domain", "")),
-		AuthClientID:         getEnv("AUTH_CLIENT_ID", getINIValue(cfg, "auth0", "auth_client_id", "")),
-		SigningMethod:        getEnv("JWT_SIGNING_METHOD", getINIValue(cfg, "auth0", "signing_method", "")),
-		DBTLSMode:            getEnv("DB_TLS_MODE", getINIValue(cfg, "db", "tls_mode", "")),
-		ChatGptApiKey:        getEnv("CHAT_GPT_API_KEY", getINIValue(cfg, "chatgpt", "api_key", "")),
-		MicrocmsApiKey:       getEnv("MICROCMS_API_KEY", getINIValue(cfg, "microcms", "api_key", "")),
-		MicrocmsOcrContentID: getEnv("MICROCMS_OCR_CONTENT_ID", getINIValue(cfg, "microcms", "ocr_content_id", "")),
+		DBUser:                       getEnv("DB_USER", getINIValue(cfg, "db", "user", "")),
+		DBPassword:                   getEnv("DB_PASSWORD", getINIValue(cfg, "db", "password", "")),
+		DBHost:                       getEnv("DB_HOST", getINIValue(cfg, "db", "host", "")),
+		DBPort:                       getEnv("DB_PORT", getINIValue(cfg, "db", "port", "")),
+		DBName:                       getEnv("DB_NAME", getINIValue(cfg, "db", "name", "")),
+		CACertPath:                   getEnv("CA_CERT_PATH", getINIValue(cfg, "db", "ca_cert_path", "")),
+		ServerAddress:                getEnv("SERVER_ADDRESS", getINIValue(cfg, "server", "address", "")),
+		ServerPort:                   getEnv("SERVER_PORT", getINIValue(cfg, "server", "port", "")),
+		APIKey1:                      getEnv("API_KEY1", getINIValue(cfg, "api", "key1", "")),
+		APIKey2:                      getEnv("API_KEY2", getINIValue(cfg, "api", "key2", "")),
+		APIKey3:                      getEnv("API_KEY3", getINIValue(cfg, "api", "key3", "")),
+		AuthDomain:                   getEnv("AUTH_DOMAIN", getINIValue(cfg, "auth0", "auth_domain", "")),
+		AuthClientID:                 getEnv("AUTH_CLIENT_ID", getINIValue(cfg, "auth0", "auth_client_id", "")),
+		SigningMethod:                getEnv("JWT_SIGNING_METHOD", getINIValue(cfg, "auth0", "signing_method", "")),
+		DBTLSMode:                    getEnv("DB_TLS_MODE", getINIValue(cfg, "db", "tls_mode", "")),
+		ChatGptApiKey:                getEnv("CHAT_GPT_API_KEY", getINIValue(cfg, "chatgpt", "api_key", "")),
+		MicrocmsApiKey:               getEnv("MICROCMS_API_KEY", getINIValue(cfg, "microcms", "api_key", "")),
+		MicrocmsOcrContentID:         getEnv("MICROCMS_OCR_CONTENT_ID", getINIValue(cfg, "microcms", "ocr_content_id", "")),
+		MicrocmsGenerateQAsContentID: getEnv("MICROCMS_GENERATE_QAS_CONTENT_ID", getINIValue(cfg, "microcms", "generate_qas_content_id", "")),
 	}
 
 	if Config.DBUser == "" {
@@ -123,6 +125,9 @@ func LoadConfig() (ConfigList, error) {
 	}
 	if Config.MicrocmsOcrContentID == "" {
 		missingConfig = append(missingConfig, "MICROCMS_OCR_CONTENT_ID")
+	}
+	if Config.MicrocmsGenerateQAsContentID == "" {
+		missingConfig = append(missingConfig, "MICROCMS_GENERATE_QAS_CONTENT_ID")
 	}
 
 	if len(missingConfig) > 0 {

--- a/src/go.mod
+++ b/src/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/microcmsio/microcms-go-sdk v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect

--- a/src/go.sum
+++ b/src/go.sum
@@ -39,6 +39,8 @@ github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovk
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/microcmsio/microcms-go-sdk v1.1.0 h1:JANxoDUICCNXNJRZkbfs5QHihWE3UgEsneLuNvwLRNc=
+github.com/microcmsio/microcms-go-sdk v1.1.0/go.mod h1:ZTjR7arfNqgcE9wgT87n8MMGvcjy1+cbtKXWgXOw/iw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=

--- a/src/infrastructure/chatgpt/chatgpt_api.go
+++ b/src/infrastructure/chatgpt/chatgpt_api.go
@@ -136,8 +136,16 @@ func (client *ChatGptClient) Ocr(ctx context.Context, imageURL string, contentID
 	return content, nil
 }
 
-func (client *ChatGptClient) GenerateQas(ctx context.Context, content string) ([]*appChatGPT.Qas, error) {
+func (client *ChatGptClient) GenerateQas(ctx context.Context, content, microcmsContentID string) ([]*appChatGPT.Qas, error) {
 	logging.Logger.Info("GenerateQas 実行開始")
+
+	prompt, err := client.microcmsClient.GetPrompt(microcmsContentID)
+	if err != nil {
+		return nil, fmt.Errorf("プロンプトの取得に失敗しました: %w", err)
+	}
+	if prompt == "" {
+		return nil, fmt.Errorf("プロンプトが空です")
+	}
 
 	reqBody := map[string]interface{}{
 		"model": modelName,
@@ -147,7 +155,7 @@ func (client *ChatGptClient) GenerateQas(ctx context.Context, content string) ([
 				"content": []map[string]interface{}{
 					{
 						"type": "text",
-						"text": "上記の文章から一問一答を５つ作成してください。質問は「Q.」、解答は「A.」で始めてください。",
+						"text": prompt,
 					},
 					{
 						"type": "text",

--- a/src/infrastructure/chatgpt/chatgpt_api.go
+++ b/src/infrastructure/chatgpt/chatgpt_api.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	appChatGPT "github.com/shinya-ac/server1Q1A/application/chatgpt"
+	"github.com/shinya-ac/server1Q1A/application/microcms"
 	config "github.com/shinya-ac/server1Q1A/configs"
 	"github.com/shinya-ac/server1Q1A/pkg/logging"
 )
@@ -20,15 +21,17 @@ const (
 )
 
 type ChatGptClient struct {
-	apiKey     string
-	httpClient *http.Client
+	apiKey         string
+	httpClient     *http.Client
+	microcmsClient microcms.MicrocmsClient
 }
 
-func NewChatGptClient() *ChatGptClient {
+func NewChatGptClient(microcmsClient microcms.MicrocmsClient) *ChatGptClient {
 	chatgptApiKey := config.Config.ChatGptApiKey
 	return &ChatGptClient{
-		apiKey:     chatgptApiKey,
-		httpClient: &http.Client{Timeout: 50 * time.Second},
+		apiKey:         chatgptApiKey,
+		httpClient:     &http.Client{Timeout: 50 * time.Second},
+		microcmsClient: microcmsClient,
 	}
 }
 
@@ -87,8 +90,16 @@ func (client *ChatGptClient) sendRequest(ctx context.Context, reqBody map[string
 	return &result, nil
 }
 
-func (client *ChatGptClient) Ocr(ctx context.Context, imageURL string) (string, error) {
+func (client *ChatGptClient) Ocr(ctx context.Context, imageURL string, contentID string) (string, error) {
 	logging.Logger.Info("Ocr 実行開始", "imageURL", imageURL)
+
+	prompt, err := client.microcmsClient.GetPrompt(contentID)
+	if err != nil {
+		return "", fmt.Errorf("プロンプトの取得に失敗しました: %w", err)
+	}
+	if prompt == "" {
+		return "", fmt.Errorf("プロンプトが空です")
+	}
 
 	reqBody := map[string]interface{}{
 		"model": modelName,
@@ -98,7 +109,7 @@ func (client *ChatGptClient) Ocr(ctx context.Context, imageURL string) (string, 
 				"content": []map[string]interface{}{
 					{
 						"type": "text",
-						"text": "画像からテキストを抽出してください。すなわちOCRを行なって欲しいということです。文字は縦読みの可能性も横読みの可能性もあります。よく観察して抽出してください。",
+						"text": prompt,
 					},
 					{
 						"type": "image_url",

--- a/src/infrastructure/microcms/microcms_api.go
+++ b/src/infrastructure/microcms/microcms_api.go
@@ -1,0 +1,38 @@
+package microcms
+
+import (
+	"fmt"
+
+	"github.com/microcmsio/microcms-go-sdk"
+)
+
+type MicrocmsClient struct {
+	client *microcms.Client
+}
+
+func NewMicrocmsClient(apiKey string) *MicrocmsClient {
+	client := microcms.New("prompt", apiKey)
+	return &MicrocmsClient{client: client}
+}
+
+type microCMSPromptResponse struct {
+	Prompt string `json:"prompt"`
+}
+
+func (r *MicrocmsClient) GetPrompt(contentID string) (string, error) {
+	var content microCMSPromptResponse
+
+	fmt.Printf("contentId:%v", contentID)
+	err := r.client.Get(
+		microcms.GetParams{
+			Endpoint:  "get",
+			ContentID: contentID,
+		},
+		&content,
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch prompt from microCMS: %w", err)
+	}
+
+	return content.Prompt, nil
+}

--- a/src/presentation/chatgpt/handler.go
+++ b/src/presentation/chatgpt/handler.go
@@ -46,7 +46,7 @@ func (h handler) Ocr(ctx echo.Context) error {
 		return err
 	}
 
-	response, err := h.ocrUseCase.HandleImageAnalysis(ctx.Request().Context(), params.ImageURL)
+	response, err := h.ocrUseCase.HandleOcr(ctx.Request().Context(), params.ImageURL)
 	if err != nil {
 		logging.Logger.Error("ChatGPT APIの実行に失敗", "error", err)
 		settings.ReturnError(ctx, err)

--- a/src/server/route/route.go
+++ b/src/server/route/route.go
@@ -8,7 +8,9 @@ import (
 	chatgptApp "github.com/shinya-ac/server1Q1A/application/chatgpt"
 	folderApp "github.com/shinya-ac/server1Q1A/application/folder"
 	qaApp "github.com/shinya-ac/server1Q1A/application/qa"
+	config "github.com/shinya-ac/server1Q1A/configs"
 	"github.com/shinya-ac/server1Q1A/infrastructure/chatgpt"
+	"github.com/shinya-ac/server1Q1A/infrastructure/microcms"
 	"github.com/shinya-ac/server1Q1A/infrastructure/mysql/db"
 	"github.com/shinya-ac/server1Q1A/infrastructure/mysql/repository"
 	"github.com/shinya-ac/server1Q1A/middlewares/auth0"
@@ -51,7 +53,9 @@ func folderRoute(r *echo.Group) {
 }
 
 func chatRoute(r *echo.Group) {
-	ChatGPTRepository := chatgpt.NewChatGptClient()
+	microcmsApiKey := config.Config.MicrocmsApiKey
+	microcmsClient := microcms.NewMicrocmsClient(microcmsApiKey)
+	ChatGPTRepository := chatgpt.NewChatGptClient(microcmsClient)
 	chatgptUsecase := chatgptApp.NewChatGPTUseCase(ChatGPTRepository)
 	generateQasuseCase := chatgptApp.NewGenerateQasUseCase(ChatGPTRepository)
 	chatHandler := chatgptPre.NewHandler(chatgptUsecase, generateQasuseCase)


### PR DESCRIPTION
microcmsからプロンプトを取得するように改修

ユースケースで環境変数（またはiniファイル）からそのユースケースに該当するプロンプトが存在するmicrocms上のコンテンツIDを指定する

`ChatGptClient`のOcrまたはGenerateQasではそのコンテンツIDを用いてmicrocmsにリクエストを送り（`client.microcmsClient.GetPrompt(microcmsContentID)`）、その返却値でプロンプト（文字列）を受け取る。
後続の処理ではそのプロンプト文字列でChatGPT AIにリクエストを送る

なので`ChatGptClient`は`microCMSClient`を内包する。つまりリポジトリー同士で依存関係を持っている。

今後はできれば
「サーバー起動時に各プロンプトを取得し、それを利用する。もしmicroCMS上でプロンプトに修正が入った場合はその通知をwebhookで受け取り、サーバーはプロンプトを最新のものに切り替えて以後それを利用するようにする」といった実装に変えたい